### PR TITLE
Korean update

### DIFF
--- a/src/ISO639.php
+++ b/src/ISO639.php
@@ -94,7 +94,7 @@ class ISO639
         array('ky', 'kir', 'kir', 'kir', 'Kyrgyz', 'Кыргызча, Кыргыз тили'),
         array('kv', 'kom', 'kom', 'kom', 'Komi', 'коми кыв'),
         array('kg', 'kon', 'kon', 'kon', 'Kongo', 'Kikongo'),
-        array('ko', 'kor', 'kor', 'kor', 'Korean', '한국어, 조선어'),
+        array('ko', 'kor', 'kor', 'kor', 'Korean', '한국어'),
         array('ku', 'kur', 'kur', 'kur', 'Kurdish', 'Kurdî, كوردی‎'),
         array('kj', 'kua', 'kua', 'kua', 'Kwanyama, Kuanyama', 'Kuanyama'),
         array('la', 'lat', 'lat', 'lat', 'Latin', 'latine, lingua latina'),


### PR DESCRIPTION
Fixed the native name for Korean.  This now correctly matches what's on wikipedia.

From Korean user:
"Please delete ‘조선어’. It’s a delicate issue we should be very careful. ‘조선어’ means the North Korean language, and mentioning it may cause unintended turmoil in Korea." 