### PR TITLE
Add PHP 8.4 to test pipeline matrix

### DIFF
--- a/.github/workflows/test-pipeline.yml
+++ b/.github/workflows/test-pipeline.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         operating-system: [ ubuntu-latest ]
         php-version:
+          - "8.4"
           - "8.3"
           - "8.2"
           - "8.1"


### PR DESCRIPTION
Add PHP 8.4 supports to GHA.