### PR TITLE
Fix deprecated dynamic properties classes on test

### DIFF
--- a/tests/ISO639Test.php
+++ b/tests/ISO639Test.php
@@ -5,6 +5,8 @@ use PHPUnit\Framework\TestCase;
 
 class ISO639Test extends TestCase
 {
+    private ISO639 $iso;
+
     public function setUp(): void
     {
         $this->iso = new ISO639();


### PR DESCRIPTION
Fix the deprecated tests:

```
Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.29
Configuration: /app/phpunit.xml

DDDDDDDDDDDDDD                                                    14 / 14 (100%)

Time: 00:00.009, Memory: 8.00 MB

OK, but there were issues!
Tests: 14, Assertions: 188, Deprecations: 1.
```

That is caused by PHP 8.2 deprecated the creation of dynamic properties on classes.