### PR TITLE
Use public consts

### DIFF
--- a/src/ISO639.php
+++ b/src/ISO639.php
@@ -4,19 +4,19 @@ namespace Matriphe\ISO639;
 
 class ISO639
 {
-    private const INDEX_ISO639_1 = 0;
-    private const INDEX_ISO639_2T = 1;
-    private const INDEX_ISO639_2B = 2;
-    private const INDEX_ISO639_3 = 3;
-    private const INDEX_ENGLISH_NAME = 4;
-    private const INDEX_NATIVE_NAME = 5;
+    public const INDEX_ISO639_1 = 0;
+    public const INDEX_ISO639_2T = 1;
+    public const INDEX_ISO639_2B = 2;
+    public const INDEX_ISO639_3 = 3;
+    public const INDEX_ENGLISH_NAME = 4;
+    public const INDEX_NATIVE_NAME = 5;
 
-    private const KEY_CODE_1 = 'code1';
-    private const KEY_CODE_2T = 'code2t';
-    private const KEY_CODE_2B = 'code2b';
-    private const KEY_CODE_3 = 'code3';
-    private const KEY_ENGLISH = 'english';
-    private const KEY_NATIVE = 'native';
+    public const KEY_CODE_1 = 'code1';
+    public const KEY_CODE_2T = 'code2t';
+    public const KEY_CODE_2B = 'code2b';
+    public const KEY_CODE_3 = 'code3';
+    public const KEY_ENGLISH = 'english';
+    public const KEY_NATIVE = 'native';
 
     /*
      * Language database, based on Wikipedia.


### PR DESCRIPTION
I have been using this package to seed languages into my database. In a previous version (2.0.0?), that doesn't seem to be available anymore, I could loop through all languages and use public int indexes to get the value that I wanted.

```
public int $indexIso639_1 = 0;
public int $indexIso639_2t = 1;
public int $indexIso639_2b = 2;
public int $indexIso639_3 = 3;
public int $indexEnglishName = 4;
public int $indexNativeName = 5;
```

Now private const indexes are being used and my integration has been broken and I am unable to do this. 

By using public consts I will be able to update my code to use these instead. As they are consts it shouldn't matter that they are public as they cannot change anyway.

My integration can be updated from:
```
$iso639 = new ISO639;
$languages = $iso639->allLanguages();

foreach($languages as $language) {
    Language::create([
        'iso_639_1' => $language[$iso639->indexIso639_1],
        'iso_639_2' => $language[$iso639->indexIso639_2b],
        'name' => $language[$iso639->indexEnglishName],
    ]);
}
```

To: 
```
$languages = new ISO639;
$languages = $iso639->allLanguages();

foreach($languages as $language) {
    Language::create([
        'iso_639_1' => $language[$iso639::INDEX_ISO639_1],
        'iso_639_2' => $language[$iso639::INDEX_ISO639_2B],
        'name' => $language[$iso639::INDEX_ENGLISH_NAME],
    ]);
}
```